### PR TITLE
fix: create new base layer instances in useMapBaseLayers hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bcgov/prp-map",
   "description": "A React component for displaying a map",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "main": "dist/index.umd.js",
   "module": "dist/index.es.js",

--- a/src/hooks/useMapBaseLayers.ts
+++ b/src/hooks/useMapBaseLayers.ts
@@ -1,30 +1,10 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import VectorTileLayer from "ol/layer/VectorTile";
 import VectorTileSource from "ol/source/VectorTile";
 import MVT from "ol/format/MVT";
 import { applyStyle } from "ol-mapbox-style";
 import { useGetMapStyles } from "@/hooks";
 import { MAP_URLS } from "@/constants";
-
-// Create base layers with vector tile source and tuned settings
-const baseLayers = [
-  new VectorTileLayer({
-    declutter: true,
-    renderMode: "hybrid",
-    renderBuffer: 100,
-    updateWhileAnimating: true,
-    // Preload controls how many zoom levels beyond the current zoom level OpenLayers will
-    // load tiles for in advance at the cost of memory and cpu. Reduces white tiles while panning/zoom
-    preload: 2,
-    updateWhileInteracting: true,
-    source: new VectorTileSource({
-      format: new MVT(),
-      url: MAP_URLS.baseLayer,
-      wrapX: true,
-      cacheSize: 1024,
-    }),
-  }),
-];
 
 /**
  * Hook that creates and manages vector tile base layers
@@ -33,13 +13,35 @@ const baseLayers = [
 export const useMapBaseLayers = () => {
   const { data: glStyles } = useGetMapStyles();
 
+  const baseLayers = useMemo(
+    () => [
+      new VectorTileLayer({
+        declutter: true,
+        renderMode: "hybrid",
+        renderBuffer: 100,
+        updateWhileAnimating: true,
+        // Preload controls how many zoom levels beyond the current zoom level OpenLayers will
+        // load tiles for in advance at the cost of memory and cpu. Reduces white tiles while panning/zooming.
+        preload: 2,
+        updateWhileInteracting: true,
+        source: new VectorTileSource({
+          format: new MVT(),
+          url: MAP_URLS.baseLayer,
+          wrapX: true,
+          cacheSize: 1024,
+        }),
+      }),
+    ],
+    []
+  );
+
   useEffect(() => {
     if (glStyles) {
       baseLayers.forEach((baseLayer) => {
         applyStyle(baseLayer, glStyles, "esri");
       });
     }
-  }, [glStyles]);
+  }, [glStyles, baseLayers]);
 
   return baseLayers;
 };


### PR DESCRIPTION
### 🐛 Bug Fix: Blank Map on Resource Detail Page

This PR resolves an issue where the map appears blank when navigating to the resource detail page using the `Link` component from `react-router-dom`. The root cause was that the base layers were not properly reinitialized on navigation.

### ✅ Fix

- Updated the `useMapBaseLayers` hook to create **new instances of base layers** on each use.
- Ensures the map renders correctly when navigating via `Link`.