### PR TITLE
fix: update the extent to correctly center the map using controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bcgov/prp-map",
   "description": "A React component for displaying a map",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "main": "dist/index.umd.js",
   "module": "dist/index.es.js",
@@ -25,7 +25,9 @@
   "scripts": {
     "dev": "vite --config example/vite.config.ts",
     "build": "vite build",
-    "lint": "eslint .",
+    "build:watch": "vite build --watch --mode development",
+    "lint": "eslint src --",
+    "lint:fix": "eslint src --fix",
     "preview": "vite preview",
     "test": "vitest --mode test",
     "test:cov": "vitest run --mode test --coverage",

--- a/src/components/MapControls/MapControls.test.tsx
+++ b/src/components/MapControls/MapControls.test.tsx
@@ -3,7 +3,7 @@ import { Coordinate } from "ol/coordinate";
 import { MapControls } from "@";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_MAP_ZOOM } from "@/constants";
+import { DEFAULT_MAP_ZOOM, MAP_EXTENT_COORDINATES } from "@/constants";
 
 describe("MapControls", () => {
   const mockView = {
@@ -33,7 +33,7 @@ describe("MapControls", () => {
     render(<MapControls {...defaultProps} />);
 
     expect(
-      screen.getByLabelText("Center map to full extent"),
+      screen.getByLabelText("Center map to full extent")
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Zoom in")).toBeInTheDocument();
     expect(screen.getByLabelText("Zoom out")).toBeInTheDocument();
@@ -77,7 +77,7 @@ describe("MapControls", () => {
 
     fireEvent.click(screen.getByLabelText("Center map to full extent"));
 
-    expect(mockView.fit).toHaveBeenCalledWith([0, 0, 100, 100]);
+    expect(mockView.fit).toHaveBeenCalledWith(MAP_EXTENT_COORDINATES);
     expect(mockView.setZoom).toHaveBeenCalledWith(DEFAULT_MAP_ZOOM);
   });
 

--- a/src/components/MapControls/MapControls.tsx
+++ b/src/components/MapControls/MapControls.tsx
@@ -8,7 +8,7 @@ import {
 import { FC, memo, useCallback } from "react";
 import OlMap from "ol/Map";
 import { Coordinate } from "ol/coordinate";
-import { DEFAULT_MAP_ZOOM } from "@/constants";
+import { DEFAULT_MAP_ZOOM, MAP_EXTENT_COORDINATES } from "@/constants";
 import "@/components/MapControls/MapControls.css";
 
 interface MapControlsProps {
@@ -53,7 +53,7 @@ const MapControls: FC<MapControlsProps> = ({
   const onCenter = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      view.fit(extent ?? view.getProjection().getExtent());
+      view.fit(extent ?? MAP_EXTENT_COORDINATES);
       view.setZoom(defaultZoom);
     },
     [view, extent, defaultZoom],

--- a/src/declaration.d.ts
+++ b/src/declaration.d.ts
@@ -1,4 +1,4 @@
-export { };
+export {};
 declare module "*.module.css";
 declare global {
   interface Window {

--- a/src/hooks/useMapBaseLayers.ts
+++ b/src/hooks/useMapBaseLayers.ts
@@ -32,7 +32,7 @@ export const useMapBaseLayers = () => {
         }),
       }),
     ],
-    []
+    [],
   );
 
   useEffect(() => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,40 +4,43 @@ import react from "@vitejs/plugin-react";
 import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
 import dts from "vite-plugin-dts";
 
-export default defineConfig({
-  plugins: [react(), dts(), cssInjectedByJsPlugin()],
-  build: {
-    lib: {
-      // You still need an entry point here, but we'll override with rollupOptions.input
-      entry: path.resolve(__dirname, "src/index.ts"),
-      name: "prp-map",
-      // fileName can be a function that returns different file names per entry
-      fileName: (format, entryName) => {
-        if (entryName === "index") return `index.${format}.js`;
-        return `${entryName}.${format}.js`;
-      },
-      formats: ["es", "cjs"],
-    },
-    cssCodeSplit: false,
-    rollupOptions: {
-      input: {
-        index: path.resolve(__dirname, "src/index.ts"),
-      },
-      external: ["react", "react-dom"],
-      output: {
-        globals: {
-          react: "React",
-          "react-dom": "ReactDOM",
+export default defineConfig(({ mode }) => {
+  return {
+    plugins: [react(), dts(), cssInjectedByJsPlugin()],
+    build: {
+      lib: {
+        // You still need an entry point here, but we'll override with rollupOptions.input
+        entry: path.resolve(__dirname, "src/index.ts"),
+        name: "prp-map",
+        // fileName can be a function that returns different file names per entry
+        fileName: (format, entryName) => {
+          if (entryName === "index") return `index.${format}.js`;
+          return `${entryName}.${format}.js`;
         },
-        entryFileNames: "[name].[format].js",
+        formats: ["es", "cjs"],
+      },
+      minify: mode === "development" ? false : "esbuild",
+      cssCodeSplit: false,
+      rollupOptions: {
+        input: {
+          index: path.resolve(__dirname, "src/index.ts"),
+        },
+        external: ["react", "react-dom"],
+        output: {
+          globals: {
+            react: "React",
+            "react-dom": "ReactDOM",
+          },
+          entryFileNames: "[name].[format].js",
+        },
+      },
+      sourcemap: true,
+      emptyOutDir: true,
+    },
+    resolve: {
+      alias: {
+        "@": resolve(__dirname, "src"),
       },
     },
-    sourcemap: true,
-    emptyOutDir: true,
-  },
-  resolve: {
-    alias: {
-      "@": resolve(__dirname, "src"),
-    },
-  },
+  };
 });


### PR DESCRIPTION
**Bug Fix:**

Fixed an issue where clicking the map controls' "Center" button would incorrectly center the map using an invalid extent. The map was not centered as expected when no extent was provided by the consumer.

**Resolution:**

Implemented a fallback to use the default map extent when no consumer-defined extent is available, ensuring consistent and correct centering behavior.